### PR TITLE
checks wallet balance sufficiency

### DIFF
--- a/common/translations/lang/en.json
+++ b/common/translations/lang/en.json
@@ -527,6 +527,7 @@
     "ETHSIMPLE_STATUS_RESOLVING_SUBDOMAIN": "  Resolving $domain...",
     "ETHSIMPLE_STATUS_SUBDOMAIN_UNAVAILABLE": " **$domain** is unavailable",
     "ETHSIMPLE_STATUS_SUBDOMAIN_AVAILABLE": " **$domain** is available",
+    "ETHSIMPLE_STATUS_SUBDOMAIN_AVAILABLE_UNABLE": " **$domain** is available; insufficient ether balance.",
     "ETHSIMPLE_STATUS_WAIT_FOR_USER_CONFIRM": "  Waiting for transaction to be confirmed...",
     "ETHSIMPLE_STATUS_WAIT_FOR_MINE": "  Waiting for transaction to be mined...",
     "ETHSIMPLE_STATUS_SUBDOMAIN_OWNED_BY_USER": " You own **$domain**",


### PR DESCRIPTION
Makes it so users can't click the Purchase Domain button unless their wallet balance is above the total estimated tx cost. The estimate comes from estimatedTxCost() which takes the gasPrice set in the transaction field a long with the wallets balance and the gas limit and subdomain price from the ETHSimple constants.
Also adds a function called setGas() which is called after every resetTransactionRequested() and checks if the gasPrice is set to gas.estimates.fast (the default gasPrice for MyCrypto transactions) and if not sets it there. Added because resetTransactionRequested() sets the gasPrice to 20.